### PR TITLE
Fix path for vanilla content on MacOS

### DIFF
--- a/LoadOrderToolTwo/Utilities/Managers/LocationManager.cs
+++ b/LoadOrderToolTwo/Utilities/Managers/LocationManager.cs
@@ -71,7 +71,7 @@ internal class LocationManager
 		{
 			if (Platform == Platform.MacOSX)
 			{
-				return Path.Combine(Path.Combine(GamePath, "Resources"), "Files");
+				return Path.Combine(Path.Combine(Path.Combine(Path.Combine(GamePath, "Cities.app"), "Contents"), "Resources"), "Files");
 			}
 
 			return Path.Combine(GamePath, "Files");


### PR DESCRIPTION
Modifies search path for game content to ensure it works from the same base directory as WS contnt.

MacOS users should use the follwing `GamePath`:
```
/Users/<username>/Library/Application Support/Steam/steamapps/common/Cities_Skylines
```